### PR TITLE
Reference RFC5004 -- closes #61

### DIFF
--- a/rfc4271bis.md
+++ b/rfc4271bis.md
@@ -81,6 +81,7 @@ informative:
   RFC4272:
   RFC4456:
   RFC4760:
+  RFC5004:
   RFC5065:
 
   IS10747:
@@ -3804,7 +3805,7 @@ proven to cause route loops.
 
 * Remove from consideration all routes other than the route that
    was advertised by the BGP speaker with the lowest BGP
-   Identifier value.
+   Identifier value. ({{RFC5004}}, if used, modifies this rule.)
 
 * Prefer the route received from the lowest peer address.
 {: tiebreak}


### PR DESCRIPTION
Here is one way to address [Issue 61](https://github.com/ietf-wg-idr/RFC4271bis/issues/61). This just references the fact that 5004 ("Avoid BGP Best Path Transitions from One External to Another") exists so that an implementor can know. Another alternative would be to make the 5004 behavior mandatory always. (Other alternatives exist.)