### PR TITLE
Path Attribute Flags registry -- Closes #74

### DIFF
--- a/rfc4271bis.md
+++ b/rfc4271bis.md
@@ -4608,8 +4608,8 @@ IANA is requested to create a registry called "BGP Path Attribute Flags"
 within the "Border Gateway Protocol (BGP) Parameters" group. The allocation
 policy is Standards Action.
 
-Bit 4, marked deprecated, was proposed in
-draft-ietf-idr-optional-transitive-02 and later removed in
+Bits 0-3 are defined in {{updatefmt}}. Bit 4, marked deprecated, was
+proposed in draft-ietf-idr-optional-transitive-02 and later removed in
 draft-ietf-idr-optional-transitive-04, but not before at least one known
 implementation had shipped. At the time of writing, it is not considered
 safe to assign.


### PR DESCRIPTION
Also added subheadings for each registry (or in the case of Error Subcodes, group of registries, although we could add sub-subheadings if we want).